### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A [Model Context Protocol](https://www.anthropic.com/news/model-context-protocol) server implementation for AWS operations that currently supports S3 and DynamoDB services. All operations are automatically logged and can be accessed through the `audit://aws-operations` resource endpoint.
 
+<a href="https://glama.ai/mcp/servers/v69k6ch2gh">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/v69k6ch2gh/badge" alt="AWS Server MCP server" />
+</a>
+
 See a demo video [here](https://www.loom.com/share/99551eeb2e514e7eaf29168c47f297d1?sid=4eb54324-5546-4f44-99a0-947f80b9365c).
 
 Listed as a [Community Server](https://github.com/modelcontextprotocol/servers?tab=readme-ov-file#-community-servers) within the MCP servers repository.
@@ -54,7 +58,6 @@ npx -y @smithery/cli install mcp-server-aws --client claude
 - **s3_object_delete**: Delete an object from S3
 - **s3_object_list**: List objects in an S3 bucket
 - **s3_object_read**: Read an object's content from S3
-
 
 ### DynamoDB Operations
 


### PR DESCRIPTION
This PR adds a badge for the [AWS MCP Server](https://glama.ai/mcp/servers/v69k6ch2gh) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/v69k6ch2gh">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/v69k6ch2gh/badge" alt="AWS Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.