### PR TITLE
support boto3 client with AWS_PROFILE

### DIFF
--- a/src/mcp_server_aws/server.py
+++ b/src/mcp_server_aws/server.py
@@ -55,9 +55,13 @@ class AWSManager:
                     region_name=region_name
                 )
             else:
-                logger.debug("Using default AWS credential chain")
-                session = boto3.Session(region_name=region_name)
-
+                aws_profile = os.getenv("AWS_PROFILE")
+                if aws_profile:
+                    logger.debug(f"Using AWS profile: {aws_profile}")
+                    session = boto3.Session(profile_name=aws_profile, region_name=region_name)
+                else:
+                    logger.debug("Using default AWS credential chain")
+                    session = boto3.Session(region_name=region_name)
             return session.client(service_name)
         except Exception as e:
             logger.error(f"Failed to create boto3 client for {


### PR DESCRIPTION
This PR is to support initialize S3 client by using AWS_PROFILE environment variable if there are no AWS access key and AWS access secret key defined.

Open issue: https://github.com/rishikavikondala/mcp-server-aws/issues/5